### PR TITLE
#21 Added empty string validation to quote, title, author textfields

### DIFF
--- a/Footnote/Main Views/AddQuoteUIKit.swift
+++ b/Footnote/Main Views/AddQuoteUIKit.swift
@@ -16,6 +16,16 @@ struct AddQuoteUIKit: View {
     @State var author: String = ""
     @State var title: String = ""
     
+    // Textfield Validation
+    @State private var showEmptyTextFieldAlert = false
+    private var textFieldsAreNonEmpty: Bool {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedAuthor = author.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        return !trimmedText.isEmpty && !trimmedAuthor.isEmpty && !trimmedTitle.isEmpty
+    }
+    
     // For the height of the text field.
     @State var textHeight: CGFloat = 0
     @State var authorHeight: CGFloat = 0
@@ -140,7 +150,11 @@ struct AddQuoteUIKit: View {
                 .background(Color.white)
             
             Button(action: {
-                self.addQuote()
+                if textFieldsAreNonEmpty {
+                    self.addQuote()
+                } else {
+                    self.showEmptyTextFieldAlert = true
+                }
             }) {
                 RoundedRectangle(cornerRadius: 8)
                     .foregroundColor(.white)
@@ -151,6 +165,9 @@ struct AddQuoteUIKit: View {
                             .foregroundColor(.black)
                 )
             }
+            .alert(isPresented: $showEmptyTextFieldAlert, content: {
+                Alert(title: Text("Error Saving Quote"), message: Text("Please ensure that all text fields are filled before saving."), dismissButton: .default(Text("Ok")))
+            })
             Spacer()
             
         }.padding(.top)

--- a/Footnote/Main Views/QuoteDetailView.swift
+++ b/Footnote/Main Views/QuoteDetailView.swift
@@ -16,6 +16,16 @@ struct QuoteDetailView: View {
     @State var title: String
     @State var author: String
     
+    // Textfield Validation
+    @State private var showEmptyTextFieldAlert = false
+    private var textFieldsAreNonEmpty: Bool {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedAuthor = author.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        return !trimmedText.isEmpty && !trimmedAuthor.isEmpty && !trimmedTitle.isEmpty
+    }
+    
     @State var showImageCreator = false
     var quote: Quote
     
@@ -103,8 +113,11 @@ struct QuoteDetailView: View {
             ).padding(.horizontal)
             
             Button(action: {
-                self.updateQuote()
-                
+                if textFieldsAreNonEmpty {
+                    self.updateQuote()
+                } else {
+                    self.showEmptyTextFieldAlert = true
+                }
             }) {
                 RoundedRectangle(cornerRadius: 8)
                     .foregroundColor(.footnoteRed)
@@ -115,8 +128,10 @@ struct QuoteDetailView: View {
                             .foregroundColor(.white)
                         
                 )
-                
             }
+            .alert(isPresented: $showEmptyTextFieldAlert, content: {
+                    Alert(title: Text("Error Updating Quote"), message: Text("Please ensure that all text fields are filled before updating."), dismissButton: .default(Text("Ok")))
+            })
             
             Button(action: {
                 self.showImageCreator = true


### PR DESCRIPTION
# What It Does
Presents an error alert when any of the textfields are empty upon saving or updating a quote.

# How to Test
- Add or update a quote, with at least one of the textfields unfilled (or just has whitespace typed in).

# Screenshots 
<div>
<img src="https://user-images.githubusercontent.com/45868050/94777244-fe74ef80-0377-11eb-8592-c9d1130b7360.gif" width=300 />
<img src="https://user-images.githubusercontent.com/45868050/94777333-2cf2ca80-0378-11eb-8901-4ecdf790d10a.gif" width=300 />
</div>
