### PR TITLE
dismiss modal on save

### DIFF
--- a/Footnote/Main Views/AddQuoteUIKit.swift
+++ b/Footnote/Main Views/AddQuoteUIKit.swift
@@ -21,6 +21,8 @@ struct AddQuoteUIKit: View {
     @State var authorHeight: CGFloat = 0
     @State var titleHeight: CGFloat = 0
     
+    @Binding var showModal: Bool
+
     var textFieldHeight: CGFloat {
         let minHeight: CGFloat = 40
         let maxHeight: CGFloat = 100
@@ -141,6 +143,7 @@ struct AddQuoteUIKit: View {
             
             Button(action: {
                 self.addQuote()
+                self.showModal.toggle()
             }) {
                 RoundedRectangle(cornerRadius: 8)
                     .foregroundColor(.white)
@@ -201,7 +204,7 @@ struct AddQuoteUIKit_Previews: PreviewProvider {
     static var previews: some View {
         let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
         return Group {
-            AddQuoteUIKit().environment(\.managedObjectContext, context).environment(\.colorScheme, .light)
+            AddQuoteUIKit(showModal: .constant(true)).environment(\.managedObjectContext, context).environment(\.colorScheme, .light)
         }
         
     }

--- a/Footnote/Main Views/ContentView.swift
+++ b/Footnote/Main Views/ContentView.swift
@@ -73,7 +73,7 @@ struct ContentView: View {
         .sheet(isPresented: $showModal) {
             if self.showView == .addQuoteView {
 
-                AddQuoteUIKit().environment(\.managedObjectContext, self.managedObjectContext)
+                AddQuoteUIKit(showModal: $showModal).environment(\.managedObjectContext, self.managedObjectContext)
 
             } else {
                 // modals...


### PR DESCRIPTION
Per #23, dismisses the modal on save. I don't know how often users will mass add more than on footnote entry, so I'll be creating a feature request for that case. ie maybe something like another button below 'Save changes' called 'Save changes and write another' (phrasing could be better).