### PR TITLE
Issue#17

### DIFF
--- a/Footnote.xcodeproj/project.pbxproj
+++ b/Footnote.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0867228A24B69A6100B6938D /* DynamicHeightTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0867228924B69A6100B6938D /* DynamicHeightTextField.swift */; };
+		B17E06052525265C00DA0E44 /* MediaTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E06042525265C00DA0E44 /* MediaTypes.swift */; };
 		FC0AC73223DCD94B003219A1 /* BookCoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0AC73123DCD94B003219A1 /* BookCoverView.swift */; };
 		FC50DF2324131B0600CB5EB7 /* AddQuoteUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC50DF2224131B0600CB5EB7 /* AddQuoteUIKit.swift */; };
 		FC7C208724FB49C600A5A963 /* SuggestionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7C208624FB49C600A5A963 /* SuggestionsView.swift */; };
@@ -36,6 +37,8 @@
 
 /* Begin PBXFileReference section */
 		0867228924B69A6100B6938D /* DynamicHeightTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightTextField.swift; sourceTree = "<group>"; };
+		B17E06042525265C00DA0E44 /* MediaTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypes.swift; sourceTree = "<group>"; };
+		B17E060A252529C800DA0E44 /* FootnoteV2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = FootnoteV2.xcdatamodel; sourceTree = "<group>"; };
 		FC0AC73123DCD94B003219A1 /* BookCoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCoverView.swift; sourceTree = "<group>"; };
 		FC50DF2224131B0600CB5EB7 /* AddQuoteUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuoteUIKit.swift; sourceTree = "<group>"; };
 		FC7C208624FB49C600A5A963 /* SuggestionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsView.swift; sourceTree = "<group>"; };
@@ -137,6 +140,7 @@
 				FCD0C83223A070FE00EFA591 /* AppDelegate.swift */,
 				FCD0C83423A070FE00EFA591 /* SceneDelegate.swift */,
 				FCD0C84F23A073E900EFA591 /* Cosmetics.swift */,
+				B17E06042525265C00DA0E44 /* MediaTypes.swift */,
 				FC96BFEC23E1071C00F4BE94 /* UIColor+FootnoteQuoteColors.swift */,
 				FCD0C83B23A070FF00EFA591 /* Assets.xcassets */,
 				FCD0C84023A070FF00EFA591 /* LaunchScreen.storyboard */,
@@ -239,6 +243,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B17E06052525265C00DA0E44 /* MediaTypes.swift in Sources */,
 				FC7C208724FB49C600A5A963 /* SuggestionsView.swift in Sources */,
 				FCD0C83323A070FE00EFA591 /* AppDelegate.swift in Sources */,
 				FCD0C85023A073E900EFA591 /* Cosmetics.swift in Sources */,
@@ -393,7 +398,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Footnote/Preview Content\"";
-				DEVELOPMENT_TEAM = N2WWEZ627P;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Footnote/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -416,7 +421,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Footnote/Preview Content\"";
-				DEVELOPMENT_TEAM = N2WWEZ627P;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Footnote/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -459,9 +464,10 @@
 		FCD0C83623A070FE00EFA591 /* Footnote2.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				B17E060A252529C800DA0E44 /* FootnoteV2.xcdatamodel */,
 				FCD0C83723A070FE00EFA591 /* Footnote2.xcdatamodel */,
 			);
-			currentVersion = FCD0C83723A070FE00EFA591 /* Footnote2.xcdatamodel */;
+			currentVersion = B17E060A252529C800DA0E44 /* FootnoteV2.xcdatamodel */;
 			path = Footnote2.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Footnote/Footnote2.xcdatamodeld/.xccurrentversion
+++ b/Footnote/Footnote2.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Footnote2.xcdatamodel</string>
+	<string>FootnoteV2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Footnote/Footnote2.xcdatamodeld/FootnoteV2.xcdatamodel/contents
+++ b/Footnote/Footnote2.xcdatamodeld/FootnoteV2.xcdatamodel/contents
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19H2" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
+        <attribute name="count" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="text"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Quote" representedClassName="Quote" syncable="YES" codeGenerationType="class">
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="coverImage" optional="YES" attributeType="Binary"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="mediaType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Title" representedClassName="Title" syncable="YES" codeGenerationType="class">
+        <attribute name="count" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="text"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <elements>
+        <element name="Author" positionX="-63" positionY="9" width="128" height="73"/>
+        <element name="Quote" positionX="-63" positionY="-18" width="128" height="133"/>
+        <element name="Title" positionX="-54" positionY="18" width="128" height="73"/>
+    </elements>
+</model>

--- a/Footnote/Main Views/AddQuoteUIKit.swift
+++ b/Footnote/Main Views/AddQuoteUIKit.swift
@@ -12,6 +12,10 @@ import UIKit
 struct AddQuoteUIKit: View {
     
     @Environment(\.managedObjectContext) var managedObjectContext
+    
+    // Issue #17: Indicates the media type of the quote being added
+    @State private var mediaType = MediaType.book
+    
     @State var text: String = ""
     @State var author: String = ""
     @State var title: String = ""
@@ -71,6 +75,19 @@ struct AddQuoteUIKit: View {
     var body: some View {
         
         VStack(spacing: 20) {
+            // Issue #17: Provides the user a choice of media types to use with their quote. It is displayed in a segmented picker control
+            Picker("Media Type", selection: $mediaType) {
+                ForEach(MediaType.allCases, id:\.rawValue) {type in
+                    Text(type.stringValue).font(.largeTitle)
+                        .tag(type)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding(.horizontal)
+            .accentColor(.blue)
+            
+            Divider()
+            
             RoundedRectangle(cornerRadius: 8.0)
                 .foregroundColor(.white)
                 .frame(height: textFieldHeight)
@@ -126,7 +143,8 @@ struct AddQuoteUIKit: View {
                             .frame(height: authorFieldHeight)
                         if author.isEmpty {
                             HStack {
-                                Text("Author")
+                                // Issue #17: Changed Author to Content Creator to align with different media type options provided to the user
+                                Text("Content Creator")
                                     .foregroundColor(.gray)
                                     .padding(.horizontal)
                                 Spacer()
@@ -166,6 +184,9 @@ struct AddQuoteUIKit: View {
         quote.text = self.text
         quote.author = self.author
         quote.dateCreated = Date()
+        
+        // Issue #17: Save the media type along with the quote in coredata
+        quote.mediaType = self.mediaType.rawCoreDataValue()
         
         //        let authorItem = Author(context: self.managedObjectContext)
         //        authorItem.text = self.author

--- a/Footnote/Main Views/ContentView.swift
+++ b/Footnote/Main Views/ContentView.swift
@@ -44,8 +44,13 @@ struct ContentView: View {
                             
                             List {
                                 ForEach(self.quotes, id: \.self) { quote in
-                                    
-                                    NavigationLink(destination: QuoteDetailView(text: quote.text ?? "", title: quote.title ?? "", author: quote.author ?? "", quote: quote).environment(\.managedObjectContext, self.managedObjectContext)) {
+                                    // Issue #17: Pass Media type to the detail view
+                                    NavigationLink(destination: QuoteDetailView(text: quote.text ?? "",
+                                                title: quote.title ?? "",
+                                                author: quote.author ?? "",
+                                                mediaType: MediaType(rawValue: Int(quote.mediaType)) ?? MediaType.book,
+                                                quote: quote
+                                    ).environment(\.managedObjectContext, self.managedObjectContext)) {
                                         QuoteItemView(quote: quote)
                                     }
                                     .onReceive(self.didSave) { _ in
@@ -140,7 +145,12 @@ struct FilteredList: View {
         NavigationView {
             List {
                 ForEach(fetchRequest.wrappedValue, id: \.self) { quote in
-                    NavigationLink(destination: QuoteDetailView(text: quote.text ?? "", title: quote.title ?? "", author: quote.author ?? "", quote: quote)) {
+                    // Issue #17: Pass Media type to the detail view
+                    NavigationLink(destination: QuoteDetailView(text: quote.text ?? "",
+                                        title: quote.title ?? "",
+                                        author: quote.author ?? "",
+                                        mediaType: MediaType(rawValue: Int(quote.mediaType)) ?? MediaType.book,
+                                        quote: quote)) {
                         QuoteItemView(quote: quote)
                     }
                 }.onDelete(perform: self.removeQuote)

--- a/Footnote/Main Views/QuoteDetailView.swift
+++ b/Footnote/Main Views/QuoteDetailView.swift
@@ -16,6 +16,9 @@ struct QuoteDetailView: View {
     @State var title: String
     @State var author: String
     
+    // Issue #17: Provide the user an option to change the media type
+    @State var mediaType: MediaType
+    
     @State var showImageCreator = false
     var quote: Quote
     
@@ -72,6 +75,20 @@ struct QuoteDetailView: View {
         VStack(spacing: 20) {
             Spacer()
                 .frame(height: 5)
+            
+            // Issue #17: Show the user the media type of their quote
+            Picker("Media Type", selection: $mediaType) {
+                ForEach(MediaType.allCases, id:\.rawValue) {type in
+                    Text(type.stringValue).font(.largeTitle)
+                        .tag(type)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding(.horizontal)
+            .accentColor(.blue)
+            
+            Divider()
+            
             RoundedRectangle(cornerRadius: 8.0)
                 .stroke(Color.footnoteRed, lineWidth: 0.5)
                 .frame(height: textFieldHeight)
@@ -145,6 +162,10 @@ struct QuoteDetailView: View {
         quote.text = self.text
         quote.title = self.title
         quote.author = self.author
+        
+        // Issue #17: Persist media type in core data
+        quote.mediaType = self.mediaType.rawCoreDataValue()
+        
         do {
             try self.managedObjectContext.save()
         } catch {

--- a/Footnote/MediaTypes.swift
+++ b/Footnote/MediaTypes.swift
@@ -1,0 +1,41 @@
+//
+//  MediaTypes.swift
+//  Footnote
+//
+//  Created by Chaithra Pabbathi on 9/30/20.
+//  Copyright © 2020 Cameron Bardell. All rights reserved.
+//
+//  This file is used to fix Issue #17 (adding different media types)
+
+import Foundation
+
+enum MediaType: Int {
+    case book = 0
+    case podcast
+    case movie
+    case tvShow
+    
+    func rawCoreDataValue() -> Int16 {
+        Int16(self.rawValue)
+    }
+}
+
+struct MediaTypeImageSystemName {
+    static var bookImageName = "book.circle.fill"
+    static var podcastImageName = "mic.circle.fill"
+    static var movieImageName = "film.fill"
+    static var tvShowImageName = "tv.circle.fill"
+    
+    static func getImage(forMediaType mediaType: MediaType) -> String {
+        switch mediaType {
+        case .book:
+            return bookImageName
+        case .podcast:
+            return podcastImageName
+        case .movie:
+            return movieImageName
+        case .tvShow:
+            return tvShowImageName
+        }
+    }
+}

--- a/Footnote/MediaTypes.swift
+++ b/Footnote/MediaTypes.swift
@@ -9,33 +9,39 @@
 
 import Foundation
 
-enum MediaType: Int {
+enum MediaType: Int, CaseIterable {
     case book = 0
     case podcast
     case movie
     case tvShow
     
+    var stringValue: String {
+        switch self {
+        case .book:
+            return "Book"
+        case .podcast:
+            return "Podcast"
+        case .movie:
+            return "Movie"
+        case .tvShow:
+            return "TV Show"
+        }
+    }
+    
     func rawCoreDataValue() -> Int16 {
         Int16(self.rawValue)
     }
-}
-
-struct MediaTypeImageSystemName {
-    static var bookImageName = "book.circle.fill"
-    static var podcastImageName = "mic.circle.fill"
-    static var movieImageName = "film.fill"
-    static var tvShowImageName = "tv.circle.fill"
     
-    static func getImage(forMediaType mediaType: MediaType) -> String {
-        switch mediaType {
+    func getImage() -> String {
+        switch self {
         case .book:
-            return bookImageName
+            return "book.circle.fill"
         case .podcast:
-            return podcastImageName
+            return "mic.circle.fill"
         case .movie:
-            return movieImageName
+            return "film.fill"
         case .tvShow:
-            return tvShowImageName
+            return "tv.circle.fill"
         }
     }
 }

--- a/Footnote/Supporting Views/QuoteItemView.swift
+++ b/Footnote/Supporting Views/QuoteItemView.swift
@@ -29,8 +29,14 @@ struct QuoteItemView: View {
             
             HStack(alignment: .bottom) {
                 VStack(alignment: .leading, spacing: 10) {
-                    Text("\(quote.title ?? "")").font(.body)
-                        .foregroundColor(Color.footnoteRed)
+                    HStack {
+                        Image(systemName: MediaTypeImageSystemName.getImage(forMediaType: MediaType(rawValue: Int(quote.mediaType)) ?? .book))
+                            .foregroundColor(Color.footnoteLightRed)
+                            .font(.title)
+                        
+                        Text("\(quote.title ?? "")").font(.body)
+                            .foregroundColor(Color.footnoteRed)
+                    }
                     Text("by \(quote.author ?? "")").font(.body)
                         .foregroundColor(Color.footnoteRed)
                 }
@@ -62,9 +68,34 @@ struct QuoteItemView_Previews: PreviewProvider {
         newQuote.author = "author"
         newQuote.title = "title"
         newQuote.dateCreated = Date()
+        
+        let newQuotePodcast = Quote.init(context: context)
+        newQuotePodcast.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum et urna vitae nunc ullamcorper auctor id a justo. Ut rutrum sapien metus, at congue arcu imperdiet sed. Sed tristique quam ullamcorper magna lobortis dapibus."
+        newQuotePodcast.author = "author"
+        newQuotePodcast.title = "title"
+        newQuotePodcast.dateCreated = Date()
+        newQuotePodcast.mediaType = 1
+        
+        let newQuoteMovie = Quote.init(context: context)
+        newQuoteMovie.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum et urna vitae nunc ullamcorper auctor id a justo. Ut rutrum sapien metus, at congue arcu imperdiet sed. Sed tristique quam ullamcorper magna lobortis dapibus."
+        newQuoteMovie.author = "author"
+        newQuoteMovie.title = "title"
+        newQuoteMovie.dateCreated = Date()
+        newQuoteMovie.mediaType = 2
+        
+        let newQuoteTvShow = Quote.init(context: context)
+        newQuoteTvShow.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum et urna vitae nunc ullamcorper auctor id a justo. Ut rutrum sapien metus, at congue arcu imperdiet sed. Sed tristique quam ullamcorper magna lobortis dapibus."
+        newQuoteTvShow.author = "author"
+        newQuoteTvShow.title = "title"
+        newQuoteTvShow.dateCreated = Date()
+        newQuoteTvShow.mediaType = 3
+        
         return VStack {
             Divider()
             QuoteItemView(quote: newQuote)
+            QuoteItemView(quote: newQuotePodcast)
+            QuoteItemView(quote: newQuoteMovie)
+            QuoteItemView(quote: newQuoteTvShow)
             Divider()
         }.padding()
     }

--- a/Footnote/Supporting Views/QuoteItemView.swift
+++ b/Footnote/Supporting Views/QuoteItemView.swift
@@ -29,8 +29,9 @@ struct QuoteItemView: View {
             
             HStack(alignment: .bottom) {
                 VStack(alignment: .leading, spacing: 10) {
+                    // Issue #17: Instead of just displaying the title of the quote, app displays the associated media type as an image preceding the title
                     HStack {
-                        Image(systemName: MediaTypeImageSystemName.getImage(forMediaType: MediaType(rawValue: Int(quote.mediaType)) ?? .book))
+                        Image(systemName: (MediaType(rawValue: Int(quote.mediaType)) ?? .book).getImage())
                             .foregroundColor(Color.footnoteLightRed)
                             .font(.title)
                         


### PR DESCRIPTION
# ISSUE \#17: Support for different types of media

## Description
The current author, title, quote setup only corresponds to books. When creating a quote, it should be possible to select different media types such as podcasts, movies, tv shows, etc.

## Implementation
Following change were implemented
1. Created a new version of CoreData. App will automatically migrate existing data into new version using a light-weight migration
2. List screen shows an image indicating the media type
3. Picker control is added to Add screen so user can select a media type while adding a quote.
4. If an existing quote is selected, detail screen displays a picker and the user has the ability to change and save it under a new media type.

## Details
### Core data changes
New version of xcdatamodeld is called **FootnoteV2** and the quote entity now has a new attribute called mediaType which defaults to 0 (for books, thus getting old data upto date with the new version)
<img width="366" alt="New CoreData Version created" src="https://user-images.githubusercontent.com/61882556/94858055-0e341880-03f8-11eb-8ab9-84177d2edb16.png"> <img width="351" alt="New attribute in Quote Entity" src="https://user-images.githubusercontent.com/61882556/94858402-9aded680-03f8-11eb-8525-8c2753d1eb7b.png">

### List Screen
A new image icon precedes the title of the quote indicating the media type. 

Here are the before and after migration screenshots.
<img height="488" alt="Before-ListScreen" src="https://user-images.githubusercontent.com/61882556/94858544-ceb9fc00-03f8-11eb-86af-0450ec7e4711.png"> <img height="488" alt="After-ListScreen" src="https://user-images.githubusercontent.com/61882556/94858567-d8436400-03f8-11eb-8ecd-164d4e327473.png">

And, here are the quotes under new media types.
<img height="488" alt="After-ListScreenAfterNewQuotesAdded" src="https://user-images.githubusercontent.com/61882556/94858671-04f77b80-03f9-11eb-8c45-7461256c78f3.png">

### Add quote
A new segmented picker control is added to the top of the screen. Instead of Author, this screen refers to the text field as 'Content Creator' to better associate it with other media types.

Here are the before and after screenshots.
<img height="488" alt="Before-NewQuoteScreen" src="https://user-images.githubusercontent.com/61882556/94858841-41c37280-03f9-11eb-9c80-082b57b9e1be.png"> <img height="488" alt="After-NewQuoteScreen" src="https://user-images.githubusercontent.com/61882556/94858857-4851ea00-03f9-11eb-9fc4-524e34192789.png">

### Detail Screen
An existing quote, when opened in the detail screen can be used to change the media type. Here are the before and after screenshots.
<img height="488" alt="Before-EditScreen" src="https://user-images.githubusercontent.com/61882556/94859039-88b16800-03f9-11eb-835b-b0ed7bc373c0.png"> <img height="488" alt="After-EditScreen" src="https://user-images.githubusercontent.com/61882556/94859050-8f3fdf80-03f9-11eb-87b0-a6c681a212b9.png">

Here is an example of how a quote looks in the list screen after changing its media type.
<img width="351" alt="Before-EditMediaTypeinDetailView" src="https://user-images.githubusercontent.com/61882556/94859173-bc8c8d80-03f9-11eb-9a91-0dc3d6aca080.png"> <img width="351" alt="After-EditMediaTypeinDetailView" src="https://user-images.githubusercontent.com/61882556/94859221-cdd59a00-03f9-11eb-8341-7ef8cfebd640.png">

### Final Note
No changes were deemed necessary in 'Share quote' screen as it only displays the quote and the title. Adding media type would not aesthetically improve the image in any way. 