### PR TITLE
#20 Fixed invisible text in textfield while in dark mode

### DIFF
--- a/Footnote/Main Views/AddQuoteUIKit.swift
+++ b/Footnote/Main Views/AddQuoteUIKit.swift
@@ -109,6 +109,7 @@ struct AddQuoteUIKit: View {
                         DynamicHeightTextField(text: $text, height: $textHeight)
                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                             .frame(height: textFieldHeight)
+                            .colorScheme(.light)
                         if text.isEmpty {
                             HStack {
                                 Text("Text")
@@ -131,6 +132,7 @@ struct AddQuoteUIKit: View {
                         DynamicHeightTextField(text: $title, height: $titleHeight)
                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                             .frame(height: titleFieldHeight)
+                            .colorScheme(.light)
                         if title.isEmpty {
                             HStack {
                                 Text("Title").padding(.horizontal)
@@ -153,6 +155,7 @@ struct AddQuoteUIKit: View {
                         DynamicHeightTextField(text: $author, height: $authorHeight)
                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                             .frame(height: authorFieldHeight)
+                            .colorScheme(.light)
                         if author.isEmpty {
                             HStack {
                                 // Issue #17: Changed Author to Content Creator to align with different media type options provided to the user

--- a/Footnote/Supporting Views/SuggestionsView.swift
+++ b/Footnote/Supporting Views/SuggestionsView.swift
@@ -20,9 +20,11 @@ struct SuggestionsView: View {
         VStack {
             HStack {
                 Text("See Me")
+                    .colorScheme(.light)
                 VStack {
                     ForEach(fetcher.books, id: \.self) { book in
                         Text(book.title)
+                            .colorScheme(.light)
                     }
                 }
             }


### PR DESCRIPTION
# What it Does and Rationale
- Added view modifier `.colorScheme(.light)` to `DynamicHeightTextField`s in `AddQuoteUIKit`, and `SuggestionsView` in order to display black text while in Dark Mode.
- Rationale: Since `DynamicHeightTextField` is an instance of `UIViewRepresentable`, it is not possible to change or choose the underlying `TextView` text color in the class.  `DynamicHeightTextField` used in multiple places outside of `AddQuoteUIKit`, so the addition of this modifier is the best option to target the textfields in `AddQuoteUIKit` only.

# How to Test
- Switch to dark mode and confirm text in textfields, as well as the "See Me" (suggestions view), are visible.

# Screenshots
<img src="https://user-images.githubusercontent.com/45868050/94972320-dbecee80-04bd-11eb-97f0-8cc8e49068ad.gif" width=275 />
