### PR TITLE
Swift Linter

### DIFF
--- a/Footnote.xcodeproj/project.pbxproj
+++ b/Footnote.xcodeproj/project.pbxproj
@@ -131,7 +131,6 @@
 				D160ACFE7F1C5771019432CC /* Pods-Footnote.debug.xcconfig */,
 				7BDD8573C02C2BDDD6F078FB /* Pods-Footnote.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -256,6 +255,7 @@
 				FCD0C82B23A070FE00EFA591 /* Sources */,
 				FCD0C82C23A070FE00EFA591 /* Frameworks */,
 				FCD0C82D23A070FE00EFA591 /* Resources */,
+				FFDFDBC72530CEEC00BBDEF9 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -372,6 +372,23 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		FFDFDBC72530CEEC00BBDEF9 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which \"${PODS_ROOT}/SwiftLint/swiftlint\" >/dev/null; then\n    ${PODS_ROOT}/SwiftLint/swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Footnote.xcodeproj/project.pbxproj
+++ b/Footnote.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0867228A24B69A6100B6938D /* DynamicHeightTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0867228924B69A6100B6938D /* DynamicHeightTextField.swift */; };
 		3F2500982527683A00FD83E4 /* ShareSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2500972527683A00FD83E4 /* ShareSheetView.swift */; };
+		70818478E0D5F9B542E74E31 /* Pods_Footnote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90E00C7A554BE25433F1729D /* Pods_Footnote.framework */; };
 		B17E06052525265C00DA0E44 /* MediaTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E06042525265C00DA0E44 /* MediaTypes.swift */; };
 		CFB112FE252B57DF0052A710 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB112FD252B57DF0052A710 /* OnboardingView.swift */; };
 		CFB11302252B58530052A710 /* Button+Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB11301252B58530052A710 /* Button+Modifier.swift */; };
@@ -55,12 +56,15 @@
 /* Begin PBXFileReference section */
 		0867228924B69A6100B6938D /* DynamicHeightTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightTextField.swift; sourceTree = "<group>"; };
 		3F2500972527683A00FD83E4 /* ShareSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetView.swift; sourceTree = "<group>"; };
+		7BDD8573C02C2BDDD6F078FB /* Pods-Footnote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Footnote.release.xcconfig"; path = "Target Support Files/Pods-Footnote/Pods-Footnote.release.xcconfig"; sourceTree = "<group>"; };
+		90E00C7A554BE25433F1729D /* Pods_Footnote.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Footnote.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B17E06042525265C00DA0E44 /* MediaTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypes.swift; sourceTree = "<group>"; };
 		B17E060A252529C800DA0E44 /* FootnoteV2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = FootnoteV2.xcdatamodel; sourceTree = "<group>"; };
 		CFB112FD252B57DF0052A710 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		CFB11301252B58530052A710 /* Button+Modifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+Modifier.swift"; sourceTree = "<group>"; };
 		CFBA65B5252AE811003A39B3 /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		CFBA65C2252AEA0E003A39B3 /* OnboardingGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingGroupView.swift; sourceTree = "<group>"; };
+		D160ACFE7F1C5771019432CC /* Pods-Footnote.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Footnote.debug.xcconfig"; path = "Target Support Files/Pods-Footnote/Pods-Footnote.debug.xcconfig"; sourceTree = "<group>"; };
 		FC0AC73123DCD94B003219A1 /* BookCoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCoverView.swift; sourceTree = "<group>"; };
 		FC3FB7AC252908BA00F7DC5F /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		FC50DF2224131B0600CB5EB7 /* AddQuoteUIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuoteUIKit.swift; sourceTree = "<group>"; };
@@ -99,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70818478E0D5F9B542E74E31 /* Pods_Footnote.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,6 +117,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0CF7110FD5C159D62698990E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				90E00C7A554BE25433F1729D /* Pods_Footnote.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CE06290C7D722E2D842B596A /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D160ACFE7F1C5771019432CC /* Pods-Footnote.debug.xcconfig */,
+				7BDD8573C02C2BDDD6F078FB /* Pods-Footnote.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		CFB11300252B57EE0052A710 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -168,6 +191,8 @@
 				FCD0C83123A070FE00EFA591 /* Footnote */,
 				FFF89964252F165B00CEC44B /* FastlaneSnapshots */,
 				FCD0C83023A070FE00EFA591 /* Products */,
+				CE06290C7D722E2D842B596A /* Pods */,
+				0CF7110FD5C159D62698990E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -227,6 +252,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FCD0C84623A070FF00EFA591 /* Build configuration list for PBXNativeTarget "Footnote" */;
 			buildPhases = (
+				B8879BFE165F5578C3EE408B /* [CP] Check Pods Manifest.lock */,
 				FCD0C82B23A070FE00EFA591 /* Sources */,
 				FCD0C82C23A070FE00EFA591 /* Frameworks */,
 				FCD0C82D23A070FE00EFA591 /* Resources */,
@@ -236,8 +262,6 @@
 			dependencies = (
 			);
 			name = Footnote;
-			packageProductDependencies = (
-			);
 			productName = Footnote2;
 			productReference = FCD0C82F23A070FE00EFA591 /* Footnote.app */;
 			productType = "com.apple.product-type.application";
@@ -288,8 +312,6 @@
 				Base,
 			);
 			mainGroup = FCD0C82623A070FE00EFA591;
-			packageReferences = (
-			);
 			productRefGroup = FCD0C83023A070FE00EFA591 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -327,6 +349,31 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B8879BFE165F5578C3EE408B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Footnote-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		FCD0C82B23A070FE00EFA591 /* Sources */ = {
@@ -505,6 +552,7 @@
 		};
 		FCD0C84723A070FF00EFA591 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D160ACFE7F1C5771019432CC /* Pods-Footnote.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -530,6 +578,7 @@
 		};
 		FCD0C84823A070FF00EFA591 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7BDD8573C02C2BDDD6F078FB /* Pods-Footnote.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,10 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'Footnote' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for Footnote
+pod 'SwiftLint'
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - SwiftLint (0.40.3)
+
+DEPENDENCIES:
+  - SwiftLint
+
+SPEC REPOS:
+  trunk:
+    - SwiftLint
+
+SPEC CHECKSUMS:
+  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+
+PODFILE CHECKSUM: 8df47dd9fc09b0f0e0d5f84a4e3ee65cc06b490a
+
+COCOAPODS: 1.9.3


### PR DESCRIPTION
I have added Swift Linter to Xcode build scheme. I will add support for Fastlane also but before that, as the default rules stand, there are over 245 Warnings and 16 Errors.  Do you want to edit or leave some rules?

I have used cocoapods for installing Swift Linter as I thought that would be easier for all the contributors to use.